### PR TITLE
Fixes for calculations based on .week

### DIFF
--- a/Sources/Int+Timepiece.swift
+++ b/Sources/Int+Timepiece.swift
@@ -24,7 +24,7 @@ public extension Int {
     }
     
     var week: Duration {
-        return Duration(value: self, unit: .CalendarUnitWeekday)
+        return Duration(value: self, unit: .CalendarUnitWeekOfYear)
     }
     var weeks: Duration {
         return week

--- a/Tests/Int+TimepieceTests.swift
+++ b/Tests/Int+TimepieceTests.swift
@@ -32,11 +32,11 @@ class IntTestCase: XCTestCase {
     
     func testWeek() {
         XCTAssertEqual(1.week.value, 1, "")
-        XCTAssertEqual(1.week.unit, NSCalendarUnit.CalendarUnitWeekday, "")
+        XCTAssertEqual(1.week.unit, NSCalendarUnit.CalendarUnitWeekOfYear, "")
     }
     func testWeeks() {
         XCTAssertEqual(2.weeks.value, 2, "")
-        XCTAssertEqual(2.weeks.unit, NSCalendarUnit.CalendarUnitWeekday, "")
+        XCTAssertEqual(2.weeks.unit, NSCalendarUnit.CalendarUnitWeekOfYear, "")
     }
     
     func testDay() {

--- a/Tests/NSDate+TimepieceTests.swift
+++ b/Tests/NSDate+TimepieceTests.swift
@@ -24,12 +24,19 @@ class NSDateTestCase: XCTestCase {
     }
     
     func testPlus() {
-        let nextWeek = calendar.dateByAddingUnit(.CalendarUnitWeekday, value: 1, toDate: now, options: .SearchBackwards)!
+        let nextDay = calendar.dateByAddingUnit(.CalendarUnitDay, value: 1, toDate: now, options: .SearchBackwards)!
+        XCTAssertEqual(now + 1.day, nextDay, "")
+        
+        let nextWeek = calendar.dateByAddingUnit(.CalendarUnitWeekOfYear, value: 1, toDate: now, options: .SearchBackwards)!
         XCTAssertEqual(now + 1.week, nextWeek, "")
     }
     
+    
     func testMinus() {
-        let lastWeek = calendar.dateByAddingUnit(.CalendarUnitWeekday, value: -1, toDate: now, options: .SearchBackwards)!
+        let lastDay = calendar.dateByAddingUnit(.CalendarUnitDay, value: -1, toDate: now, options: .SearchBackwards)!
+        XCTAssertEqual(now - 1.day, lastDay, "")
+        
+        let lastWeek = calendar.dateByAddingUnit(.CalendarUnitWeekOfYear, value: -1, toDate: now, options: .SearchBackwards)!
         XCTAssertEqual(now - 1.week, lastWeek, "")
     }
     


### PR DESCRIPTION
I noticed that .week is using `NSCalendarUnit.CalendarUnitWeekday` which only adds a single day to the the `NSDate` instance where I think it is expected to add 7 days. Therefore to seems like bug to me and can be fixed by using `NSCalendarUnit.CalendarUnitWeekOfYear` instead. 