### PR TITLE
iOS 7 compatibility

### DIFF
--- a/Sources/Duration.swift
+++ b/Sources/Duration.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+prefix func - (duration: Duration) -> (Duration) {
+    return Duration(value: -duration.value, unit: duration.unit)
+}
+
 public class Duration {
     public let value: Int
     public let unit: NSCalendarUnit
@@ -17,14 +21,14 @@ public class Duration {
         Initialize a date before a duration.
     */
     public var ago: NSDate {
-        return calendar.dateByAddingUnit(unit, value: -value, toDate: NSDate(), options: .SearchBackwards)!
+        return calendar.dateByAddingDuration(-self, toDate: NSDate(), options: .SearchBackwards)!
     }
     
     /**
         Initialize a date after a duration.
     */
     public var later: NSDate {
-        return calendar.dateByAddingUnit(unit, value: value, toDate: NSDate(), options: .SearchBackwards)!
+        return calendar.dateByAddingDuration(self, toDate: NSDate(), options: .SearchBackwards)!
     }
     
     public init(value: Int, unit: NSCalendarUnit) {

--- a/Sources/NSCalendar+Timepiece.swift
+++ b/Sources/NSCalendar+Timepiece.swift
@@ -1,0 +1,23 @@
+//
+//  NSCalendar+Timepiece.swift
+//  Timepiece
+//
+//  Created by Mattijs on 25/04/15.
+//  Copyright (c) 2015 Naoto Kaneko. All rights reserved.
+//
+
+import Foundation
+
+private let supportsDateByAddingUnit = NSCalendar.currentCalendar().respondsToSelector("dateByAddingUnit:value:toDate:options:")
+
+extension NSCalendar {
+    func dateByAddingDuration(duration: Duration, toDate date: NSDate, options opts: NSCalendarOptions) -> NSDate? {
+        if supportsDateByAddingUnit {
+            return dateByAddingUnit(duration.unit, value: duration.value, toDate: date, options: .SearchBackwards)!
+        }
+        else {
+            // otherwise fallback to NSDateComponents
+            return dateByAddingComponents(NSDateComponents(duration), toDate: date, options: .SearchBackwards)!
+        }
+    }
+}

--- a/Sources/NSDate+Timepiece.swift
+++ b/Sources/NSDate+Timepiece.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 public func + (lhs: NSDate, rhs: Duration) -> NSDate {
-    return NSCalendar.currentCalendar().dateByAddingUnit(rhs.unit, value: rhs.value, toDate: lhs, options: .SearchBackwards)!
+    return NSCalendar.currentCalendar().dateByAddingDuration(rhs, toDate: lhs, options: .SearchBackwards)!
 }
 
 public func - (lhs: NSDate, rhs: Duration) -> NSDate {
-    return NSCalendar.currentCalendar().dateByAddingUnit(rhs.unit, value: -rhs.value, toDate: lhs, options: .SearchBackwards)!
+    return NSCalendar.currentCalendar().dateByAddingDuration(-rhs, toDate: lhs, options: .SearchBackwards)!
 }
 
 public extension NSDate {

--- a/Sources/NSDateComponents+Timepiece.swift
+++ b/Sources/NSDateComponents+Timepiece.swift
@@ -1,0 +1,37 @@
+//
+//  NSDateComponents+Timepiece.swift
+//  Timepiece
+//
+//  Created by Mattijs on 25/04/15.
+//  Copyright (c) 2015 Naoto Kaneko. All rights reserved.
+//
+
+import Foundation
+
+extension NSDateComponents {
+    convenience init(_ duration: Duration) {
+        self.init()
+        switch duration.unit{
+        case NSCalendarUnit.CalendarUnitDay:
+            day = duration.value
+        case NSCalendarUnit.CalendarUnitWeekday:
+            weekday = duration.value
+        case NSCalendarUnit.CalendarUnitWeekOfMonth:
+            weekday = duration.value
+        case NSCalendarUnit.CalendarUnitWeekOfYear:
+            weekOfYear = duration.value
+        case NSCalendarUnit.CalendarUnitHour:
+            hour = duration.value
+        case NSCalendarUnit.CalendarUnitMinute:
+            minute = duration.value
+        case NSCalendarUnit.CalendarUnitMonth:
+            month = duration.value
+        case NSCalendarUnit.CalendarUnitSecond:
+            second = duration.value
+        case NSCalendarUnit.CalendarUnitYear:
+            year = duration.value
+        default:
+            () // unsupported / ignore
+        }
+    }
+}

--- a/Timepiece.xcodeproj/project.pbxproj
+++ b/Timepiece.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		3DC6182E199E270F00FB7AAC /* Int+TimepieceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC6182C199E26FE00FB7AAC /* Int+TimepieceTests.swift */; };
 		3DC61834199F0B2100FB7AAC /* NSDate+Timepiece.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC61833199F0B2100FB7AAC /* NSDate+Timepiece.swift */; };
 		3DC61836199F0C0500FB7AAC /* NSDate+TimepieceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC61835199F0C0500FB7AAC /* NSDate+TimepieceTests.swift */; };
+		DFA183011AEBC2DB00D95B9B /* NSCalendar+Timepiece.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA183001AEBC2DB00D95B9B /* NSCalendar+Timepiece.swift */; };
+		DFA183031AEBC81800D95B9B /* NSDateComponents+Timepiece.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA183021AEBC81800D95B9B /* NSDateComponents+Timepiece.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,6 +40,8 @@
 		3DC6182C199E26FE00FB7AAC /* Int+TimepieceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Int+TimepieceTests.swift"; sourceTree = "<group>"; };
 		3DC61833199F0B2100FB7AAC /* NSDate+Timepiece.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+Timepiece.swift"; sourceTree = "<group>"; };
 		3DC61835199F0C0500FB7AAC /* NSDate+TimepieceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+TimepieceTests.swift"; sourceTree = "<group>"; };
+		DFA183001AEBC2DB00D95B9B /* NSCalendar+Timepiece.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSCalendar+Timepiece.swift"; sourceTree = "<group>"; };
+		DFA183021AEBC81800D95B9B /* NSDateComponents+Timepiece.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDateComponents+Timepiece.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,10 +83,12 @@
 		3DC61828199E204800FB7AAC /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				DFA183001AEBC2DB00D95B9B /* NSCalendar+Timepiece.swift */,
 				3D36DD67199FBE6700E752F5 /* Duration.swift */,
 				3DC6182A199E26CD00FB7AAC /* Int+Timepiece.swift */,
 				3DC61833199F0B2100FB7AAC /* NSDate+Timepiece.swift */,
 				3D4453381AA2C4B900199949 /* String+Timepiece.swift */,
+				DFA183021AEBC81800D95B9B /* NSDateComponents+Timepiece.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -208,6 +214,8 @@
 				3D36DD68199FBE6700E752F5 /* Duration.swift in Sources */,
 				3DC61834199F0B2100FB7AAC /* NSDate+Timepiece.swift in Sources */,
 				3DC6182B199E26CD00FB7AAC /* Int+Timepiece.swift in Sources */,
+				DFA183031AEBC81800D95B9B /* NSDateComponents+Timepiece.swift in Sources */,
+				DFA183011AEBC2DB00D95B9B /* NSCalendar+Timepiece.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
I use this library on iOS 7. Everything works except the `NSCalendar.dateByAddingUnit:` method is unavailable on iOS 7. I implemented a `NSCalendar.dateByAddingDuration:` extension method to fallback to `NSCalendar.dateByAddingComponents:` when required, otherwise it will just use `NSCalendar.dateByAddingUnit:`