### PR TITLE
Added functions for beginning of Week and end of Week

### DIFF
--- a/Sources/NSDate+Timepiece.swift
+++ b/Sources/NSDate+Timepiece.swift
@@ -144,17 +144,11 @@ public extension NSDate {
     }
 	
 	var beginningOfWeek: NSDate {
-		var daysDiff = weekday - calendar.firstWeekday
-		if daysDiff < 0 {
-			daysDiff = 7 + daysDiff
-		}
+		var daysDiff = (7 + (weekday - calendar.firstWeekday)) % 7
 		return beginningOfDay - daysDiff.days
 	}
 	var endOfWeek: NSDate {
-		var daysDiff = (calendar.firstWeekday - 1) - weekday
-		if daysDiff < 0 {
-			daysDiff = 7 + daysDiff
-		}
+		var daysDiff = (7 + ((calendar.firstWeekday - 1) - weekday)) % 7
 		return endOfDay + daysDiff.days
 	}
     

--- a/Sources/NSDate+Timepiece.swift
+++ b/Sources/NSDate+Timepiece.swift
@@ -142,6 +142,21 @@ public extension NSDate {
         let lastDay = calendar.rangeOfUnit(.CalendarUnitDay, inUnit: .CalendarUnitMonth, forDate: self).length
         return change(day: lastDay, hour: 23, minute: 59, second: 59)
     }
+	
+	var beginningOfWeek: NSDate {
+		var daysDiff = weekday - calendar.firstWeekday
+		if daysDiff < 0 {
+			daysDiff = 7 + daysDiff
+		}
+		return beginningOfDay - daysDiff.days
+	}
+	var endOfWeek: NSDate {
+		var daysDiff = (calendar.firstWeekday - 1) - weekday
+		if daysDiff < 0 {
+			daysDiff = 7 + daysDiff
+		}
+		return endOfDay + daysDiff.days
+	}
     
     var beginningOfDay: NSDate {
         return change(hour: 0, minute: 0, second: 0)

--- a/Tests/NSDate+TimepieceTests.swift
+++ b/Tests/NSDate+TimepieceTests.swift
@@ -145,7 +145,25 @@ class NSDateTestCase: XCTestCase {
         XCTAssertEqual(now.beginningOfHour.minute, 0, "")
         XCTAssertEqual(now.beginningOfMinute.second, 0, "")
     }
-    
+	
+	func testBeginningEndOfWeek() {
+		let systemFirstWeekday = calendar.firstWeekday
+		// Birthday was on tuesday (Tuesday, June 2, 1987)
+		if systemFirstWeekday == 1 {
+			// Weeks start on sunday:
+			XCTAssertEqual(birthday.beginningOfWeek.month, 5, "")
+			XCTAssertEqual(birthday.beginningOfWeek.day, 31, "")
+			XCTAssertEqual(birthday.endOfWeek.month, 6, "")
+			XCTAssertEqual(birthday.endOfWeek.day, 6, "")
+		} else if systemFirstWeekday == 2 {
+			// Weeks start on monday:
+			XCTAssertEqual(birthday.beginningOfWeek.month, 6, "")
+			XCTAssertEqual(birthday.beginningOfWeek.day, 1, "")
+			XCTAssertEqual(birthday.endOfWeek.month, 6, "")
+			XCTAssertEqual(birthday.endOfWeek.day, 7, "")
+		}
+	}
+	
     func testEndOf() {
         XCTAssertEqual(now.endOfYear.month, 12, "")
         XCTAssertEqual(now.endOfDay.hour, 23, "")


### PR DESCRIPTION
I further extended the `beginningOfMonth` / `beginningOfDay` / `endOfMonth` / `endOfDay` functions in `NSDate+Timepiece.swift` to quickly get the first and last days of the current week.