### PR TITLE
Deprecate the comparison between Duration and NSTimeInterval

### DIFF
--- a/Sources/Duration.swift
+++ b/Sources/Duration.swift
@@ -39,6 +39,12 @@ public class Duration {
         return calendar.dateByAddingDuration(self, toDate: date, options: .SearchBackwards)!
     }
     
+    /**
+        This conversion is deprecated in 0.4.1 and will be obsoleted in 0.5.0.
+    
+        This operation is performed under incorrect assumption that 1 month is always equal to 30 days.
+    */
+    @availability(*, deprecated=0.4.1)
     public lazy var interval: NSTimeInterval = { [unowned self] in
         return self.unit.interval * NSTimeInterval(self.value)
     }()

--- a/Sources/NSCalendarUnit+Timepiece.swift
+++ b/Sources/NSCalendarUnit+Timepiece.swift
@@ -8,7 +8,14 @@
 
 import Foundation
 
+/**
+    This extension is deprecated in 0.4.1 and will be obsoleted in 0.5.0.
+
+    The conversion of Duration into NSTimeInterval is performed under incorrect assumption that 1 month is always equal to 30 days.
+    Therefore, The comparison between Duration and NSTimeInterval is also incorrect.
+*/
 public extension NSCalendarUnit {
+    @availability(*, deprecated=0.4.1)
     public var interval: NSTimeInterval {
         switch self {
         case NSCalendarUnit.CalendarUnitNanosecond:     return 1e-9                 // 1e-9 second

--- a/Sources/NSTimeInterval+Timepiece.swift
+++ b/Sources/NSTimeInterval+Timepiece.swift
@@ -8,50 +8,69 @@
 
 import Foundation
 
+/**
+    This extension is deprecated in 0.4.1 and will be obsoleted in 0.5.0.
+
+    The conversion of Duration into NSTimeInterval is performed under incorrect assumption that 1 month is always equal to 30 days.
+    Therefore, The comparison between Duration and NSTimeInterval is also incorrect.
+*/
+
+@availability(*, deprecated=0.4.1)
 public func < (lhs: NSTimeInterval, rhs: Duration) -> Bool {
     return lhs < rhs.interval
 }
 
+@availability(*, deprecated=0.4.1)
 public func < (lhs: Duration, rhs: NSTimeInterval) -> Bool {
     return lhs.interval < rhs
 }
 
+@availability(*, deprecated=0.4.1)
 public func > (lhs: NSTimeInterval, rhs: Duration) -> Bool {
     return lhs > rhs.interval
 }
 
+@availability(*, deprecated=0.4.1)
 public func > (lhs: Duration, rhs: NSTimeInterval) -> Bool {
     return lhs.interval > rhs
 }
 
+@availability(*, deprecated=0.4.1)
 public func == (lhs: NSTimeInterval, rhs: Duration) -> Bool {
     return lhs == rhs.interval
 }
 
+@availability(*, deprecated=0.4.1)
 public func == (lhs: Duration, rhs: NSTimeInterval) -> Bool {
     return lhs.interval == rhs
 }
 
+@availability(*, deprecated=0.4.1)
 public func >= (lhs: NSTimeInterval, rhs: Duration) -> Bool {
     return lhs >= rhs.interval
 }
 
+@availability(*, deprecated=0.4.1)
 public func >= (lhs: Duration, rhs: NSTimeInterval) -> Bool {
     return lhs.interval >= rhs
 }
 
+@availability(*, deprecated=0.4.1)
 public func <= (lhs: NSTimeInterval, rhs: Duration) -> Bool {
     return lhs <= rhs.interval
 }
 
+@availability(*, deprecated=0.4.1)
 public func <= (lhs: Duration, rhs: NSTimeInterval) -> Bool {
     return lhs.interval <= rhs
 }
 
+@availability(*, deprecated=0.4.1)
 public func != (lhs: NSTimeInterval, rhs: Duration) -> Bool {
     return lhs != rhs.interval
 }
 
+@availability(*, deprecated=0.4.1)
 public func != (lhs: Duration, rhs: NSTimeInterval) -> Bool {
     return lhs.interval != rhs
 }

--- a/Timepiece.playground/contents.xcplayground
+++ b/Timepiece.playground/contents.xcplayground
@@ -1,4 +1,2 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' display-mode='rendered'>
-    <timeline fileName='timeline.xctimeline'/>
-</playground>
+<playground version='5.0' target-platform='ios' display-mode='rendered'/>

--- a/Timepiece.playground/timeline.xctimeline
+++ b/Timepiece.playground/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>


### PR DESCRIPTION
This operation is performed under incorrect assumption. It will be obsoleted in 0.5.0.