### PR TITLE
Add tvOS target

### DIFF
--- a/Timepiece.xcodeproj/project.pbxproj
+++ b/Timepiece.xcodeproj/project.pbxproj
@@ -35,6 +35,21 @@
 		3DE7CFE21B27132C00E0F331 /* String+TimepieceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D44533A1AA2C50B00199949 /* String+TimepieceTests.swift */; };
 		3DE7CFE31B27132C00E0F331 /* NSTimeInterval+TimepieceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2115F11B00A02800B3AD69 /* NSTimeInterval+TimepieceTests.swift */; };
 		3DE7CFE41B27132C00E0F331 /* NSCalendarUnit+TimepieceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA29DB31B03D5F700AE149B /* NSCalendarUnit+TimepieceTests.swift */; };
+		8061C2A41BB9B62200F0494D /* Timepiece.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8061C29A1BB9B62200F0494D /* Timepiece.framework */; };
+		8061C2B11BB9B65B00F0494D /* NSCalendar+Timepiece.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA183001AEBC2DB00D95B9B /* NSCalendar+Timepiece.swift */; };
+		8061C2B21BB9B65B00F0494D /* Duration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D36DD67199FBE6700E752F5 /* Duration.swift */; };
+		8061C2B31BB9B65B00F0494D /* Int+Timepiece.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC6182A199E26CD00FB7AAC /* Int+Timepiece.swift */; };
+		8061C2B41BB9B65B00F0494D /* NSDate+Timepiece.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC61833199F0B2100FB7AAC /* NSDate+Timepiece.swift */; };
+		8061C2B51BB9B65B00F0494D /* NSTimeInterval+Timepiece.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF717DE91AFFEECC00A70D2B /* NSTimeInterval+Timepiece.swift */; };
+		8061C2B61BB9B65B00F0494D /* String+Timepiece.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4453381AA2C4B900199949 /* String+Timepiece.swift */; };
+		8061C2B71BB9B65B00F0494D /* NSDateComponents+Timepiece.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA183021AEBC81800D95B9B /* NSDateComponents+Timepiece.swift */; };
+		8061C2B81BB9B65B00F0494D /* NSCalendarUnit+Timepiece.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA29DB11B03C68000AE149B /* NSCalendarUnit+Timepiece.swift */; };
+		8061C2B91BB9B65F00F0494D /* DurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFD0DC31B07A5F700F69BA5 /* DurationTests.swift */; };
+		8061C2BA1BB9B65F00F0494D /* Int+TimepieceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC6182C199E26FE00FB7AAC /* Int+TimepieceTests.swift */; };
+		8061C2BB1BB9B65F00F0494D /* NSDate+TimepieceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC61835199F0C0500FB7AAC /* NSDate+TimepieceTests.swift */; };
+		8061C2BC1BB9B65F00F0494D /* String+TimepieceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D44533A1AA2C50B00199949 /* String+TimepieceTests.swift */; };
+		8061C2BD1BB9B65F00F0494D /* NSTimeInterval+TimepieceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2115F11B00A02800B3AD69 /* NSTimeInterval+TimepieceTests.swift */; };
+		8061C2BE1BB9B65F00F0494D /* NSCalendarUnit+TimepieceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA29DB31B03D5F700AE149B /* NSCalendarUnit+TimepieceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +66,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 3DE7CFAF1B27126F00E0F331;
 			remoteInfo = "Timepiece OSX";
+		};
+		8061C2A51BB9B62200F0494D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3DC61806199E1F8400FB7AAC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8061C2991BB9B62200F0494D;
+			remoteInfo = "Timepiece tvOS";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -70,6 +92,8 @@
 		3DE7CFBA1B27126F00E0F331 /* Timepiece OSX Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Timepiece OSX Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3DE7CFC01B27126F00E0F331 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3DE7CFC11B27126F00E0F331 /* Timepiece_OSXTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timepiece_OSXTests.swift; sourceTree = "<group>"; };
+		8061C29A1BB9B62200F0494D /* Timepiece.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Timepiece.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8061C2A31BB9B62200F0494D /* Timepiece tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Timepiece tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF2115F11B00A02800B3AD69 /* NSTimeInterval+TimepieceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSTimeInterval+TimepieceTests.swift"; sourceTree = "<group>"; };
 		DF717DE91AFFEECC00A70D2B /* NSTimeInterval+Timepiece.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSTimeInterval+Timepiece.swift"; sourceTree = "<group>"; };
 		DFA183001AEBC2DB00D95B9B /* NSCalendar+Timepiece.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSCalendar+Timepiece.swift"; sourceTree = "<group>"; };
@@ -108,6 +132,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8061C2961BB9B62200F0494D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8061C2A01BB9B62200F0494D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8061C2A41BB9B62200F0494D /* Timepiece.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -129,6 +168,8 @@
 				3DC6181A199E1F8400FB7AAC /* Timepiece iOS Tests.xctest */,
 				3DE7CFB01B27126F00E0F331 /* Timepiece.framework */,
 				3DE7CFBA1B27126F00E0F331 /* Timepiece OSX Tests.xctest */,
+				8061C29A1BB9B62200F0494D /* Timepiece.framework */,
+				8061C2A31BB9B62200F0494D /* Timepiece tvOS Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -212,6 +253,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8061C2971BB9B62200F0494D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -287,6 +335,42 @@
 			productReference = 3DE7CFBA1B27126F00E0F331 /* Timepiece OSX Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		8061C2991BB9B62200F0494D /* Timepiece tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8061C2AF1BB9B62200F0494D /* Build configuration list for PBXNativeTarget "Timepiece tvOS" */;
+			buildPhases = (
+				8061C2951BB9B62200F0494D /* Sources */,
+				8061C2961BB9B62200F0494D /* Frameworks */,
+				8061C2971BB9B62200F0494D /* Headers */,
+				8061C2981BB9B62200F0494D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Timepiece tvOS";
+			productName = "Timepiece tvOS";
+			productReference = 8061C29A1BB9B62200F0494D /* Timepiece.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		8061C2A21BB9B62200F0494D /* Timepiece tvOS Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8061C2B01BB9B62200F0494D /* Build configuration list for PBXNativeTarget "Timepiece tvOS Tests" */;
+			buildPhases = (
+				8061C29F1BB9B62200F0494D /* Sources */,
+				8061C2A01BB9B62200F0494D /* Frameworks */,
+				8061C2A11BB9B62200F0494D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8061C2A61BB9B62200F0494D /* PBXTargetDependency */,
+			);
+			name = "Timepiece tvOS Tests";
+			productName = "Timepiece tvOSTests";
+			productReference = 8061C2A31BB9B62200F0494D /* Timepiece tvOS Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -310,6 +394,12 @@
 					3DE7CFB91B27126F00E0F331 = {
 						CreatedOnToolsVersion = 6.3.2;
 					};
+					8061C2991BB9B62200F0494D = {
+						CreatedOnToolsVersion = 7.1;
+					};
+					8061C2A21BB9B62200F0494D = {
+						CreatedOnToolsVersion = 7.1;
+					};
 				};
 			};
 			buildConfigurationList = 3DC61809199E1F8400FB7AAC /* Build configuration list for PBXProject "Timepiece" */;
@@ -326,8 +416,10 @@
 			targets = (
 				3DC6180E199E1F8400FB7AAC /* Timepiece iOS */,
 				3DE7CFAF1B27126F00E0F331 /* Timepiece OSX */,
+				8061C2991BB9B62200F0494D /* Timepiece tvOS */,
 				3DC61819199E1F8400FB7AAC /* Timepiece iOS Tests */,
 				3DE7CFB91B27126F00E0F331 /* Timepiece OSX Tests */,
+				8061C2A21BB9B62200F0494D /* Timepiece tvOS Tests */,
 			);
 		};
 /* End PBXProject section */
@@ -355,6 +447,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		3DE7CFB81B27126F00E0F331 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8061C2981BB9B62200F0494D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8061C2A11BB9B62200F0494D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -420,6 +526,34 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8061C2951BB9B62200F0494D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8061C2B71BB9B65B00F0494D /* NSDateComponents+Timepiece.swift in Sources */,
+				8061C2B61BB9B65B00F0494D /* String+Timepiece.swift in Sources */,
+				8061C2B41BB9B65B00F0494D /* NSDate+Timepiece.swift in Sources */,
+				8061C2B11BB9B65B00F0494D /* NSCalendar+Timepiece.swift in Sources */,
+				8061C2B81BB9B65B00F0494D /* NSCalendarUnit+Timepiece.swift in Sources */,
+				8061C2B21BB9B65B00F0494D /* Duration.swift in Sources */,
+				8061C2B51BB9B65B00F0494D /* NSTimeInterval+Timepiece.swift in Sources */,
+				8061C2B31BB9B65B00F0494D /* Int+Timepiece.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8061C29F1BB9B62200F0494D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8061C2BD1BB9B65F00F0494D /* NSTimeInterval+TimepieceTests.swift in Sources */,
+				8061C2BB1BB9B65F00F0494D /* NSDate+TimepieceTests.swift in Sources */,
+				8061C2BA1BB9B65F00F0494D /* Int+TimepieceTests.swift in Sources */,
+				8061C2B91BB9B65F00F0494D /* DurationTests.swift in Sources */,
+				8061C2BE1BB9B65F00F0494D /* NSCalendarUnit+TimepieceTests.swift in Sources */,
+				8061C2BC1BB9B65F00F0494D /* String+TimepieceTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -432,6 +566,11 @@
 			isa = PBXTargetDependency;
 			target = 3DE7CFAF1B27126F00E0F331 /* Timepiece OSX */;
 			targetProxy = 3DE7CFBC1B27126F00E0F331 /* PBXContainerItemProxy */;
+		};
+		8061C2A61BB9B62200F0494D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8061C2991BB9B62200F0494D /* Timepiece tvOS */;
+			targetProxy = 8061C2A51BB9B62200F0494D /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -681,6 +820,80 @@
 			};
 			name = Release;
 		};
+		8061C2AB1BB9B62200F0494D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "Timepiece.xcodeproj/Timepiece-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = naoty.Timepiece;
+				PRODUCT_NAME = Timepiece;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		8061C2AC1BB9B62200F0494D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "Timepiece.xcodeproj/Timepiece-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = naoty.Timepiece;
+				PRODUCT_NAME = Timepiece;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		8061C2AD1BB9B62200F0494D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "Timepiece.xcodeproj/TimepieceTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "naoty.Timepiece-tvOS Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		8061C2AE1BB9B62200F0494D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "Timepiece.xcodeproj/TimepieceTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "naoty.Timepiece-tvOS Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -728,6 +941,22 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		8061C2AF1BB9B62200F0494D /* Build configuration list for PBXNativeTarget "Timepiece tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8061C2AB1BB9B62200F0494D /* Debug */,
+				8061C2AC1BB9B62200F0494D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		8061C2B01BB9B62200F0494D /* Build configuration list for PBXNativeTarget "Timepiece tvOS Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8061C2AD1BB9B62200F0494D /* Debug */,
+				8061C2AE1BB9B62200F0494D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Timepiece.xcodeproj/project.pbxproj
+++ b/Timepiece.xcodeproj/project.pbxproj
@@ -872,7 +872,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "Timepiece.xcodeproj/TimepieceTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "naoty.Timepiece-tvOS Tests";
+				PRODUCT_BUNDLE_IDENTIFIER = "naoty.Timepiece-tvOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -887,7 +887,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "Timepiece.xcodeproj/TimepieceTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "naoty.Timepiece-tvOS Tests";
+				PRODUCT_BUNDLE_IDENTIFIER = "naoty.Timepiece-tvOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -949,6 +949,7 @@
 				8061C2AC1BB9B62200F0494D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		8061C2B01BB9B62200F0494D /* Build configuration list for PBXNativeTarget "Timepiece tvOS Tests" */ = {
 			isa = XCConfigurationList;
@@ -957,6 +958,7 @@
 				8061C2AE1BB9B62200F0494D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Timepiece.xcodeproj/xcshareddata/xcschemes/Timepiece tvOS.xcscheme
+++ b/Timepiece.xcodeproj/xcshareddata/xcschemes/Timepiece tvOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8061C2991BB9B62200F0494D"
+               BuildableName = "Timepiece.framework"
+               BlueprintName = "Timepiece tvOS"
+               ReferencedContainer = "container:Timepiece.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8061C2A21BB9B62200F0494D"
+               BuildableName = "Timepiece tvOS Tests.xctest"
+               BlueprintName = "Timepiece tvOS Tests"
+               ReferencedContainer = "container:Timepiece.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8061C2991BB9B62200F0494D"
+            BuildableName = "Timepiece.framework"
+            BlueprintName = "Timepiece tvOS"
+            ReferencedContainer = "container:Timepiece.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8061C2991BB9B62200F0494D"
+            BuildableName = "Timepiece.framework"
+            BlueprintName = "Timepiece tvOS"
+            ReferencedContainer = "container:Timepiece.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8061C2991BB9B62200F0494D"
+            BuildableName = "Timepiece.framework"
+            BlueprintName = "Timepiece tvOS"
+            ReferencedContainer = "container:Timepiece.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
OK this one replaces #39 for now and merges in the tvOS branch.

I had a major merge conflict on the pbxproj, so I needed to manually merge them. I don't even wish my worst enemy such a task, but I hope I managed to do the merge correctly.

The code still compiles and the tests succeed even on tvOS, besides the breaking ones in #37 .

#39 will be closed for now. The tvOS branch can be merged in master as soon XCode 7.1 is released and Cocoapods supports tvOS.