### PR TITLE
Fix the specification of version on podspec

### DIFF
--- a/Timepiece.podspec
+++ b/Timepiece.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Timepiece"
-  s.version      = `git describe --tags --abbrev=0`
+  s.version      = "0.4.2"
   s.summary      = "Intuitive NSDate extensions in Swift"
   s.homepage     = "https://github.com/naoty/Timepiece"
   s.license      = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
The previous definition causes users not to install from master like https://github.com/naoty/Timepiece/issues/42.