### PR TITLE
test ISO8801 compatibility which fails

### DIFF
--- a/Tests/NSDate+TimepieceTests.swift
+++ b/Tests/NSDate+TimepieceTests.swift
@@ -220,4 +220,19 @@ class NSDateTestCase: XCTestCase {
         let timestamp = birthday.stringFromFormat("yyyy-MM-dd HH:mm:SS")
         XCTAssertEqual(timestamp, "1987-06-02 00:00:00", "")
     }
+    
+    func testStringFromISO8801Format() {
+        let timestamp = birthday.stringFromFormat("yyyy-MM-dd'T'HH:mm:ss.sssZZ")
+        XCTAssertEqual(timestamp, "1987-06-02T00:00:00.000-0400", "")
+    }
+    
+    func testDateFromISO8801FormattedString() {
+        let date = "1987-06-02T00:00:00.000-0400".dateFromFormat("yyyy-MM-dd'T'HH:mm:ss.sssZZ")
+        XCTAssertEqual(date, birthday, "")
+    }
+    
+    func testDateFromISO8801FullFormattedString() {
+        let date = "2015-10-12T01:58:18.877Z".dateFromFormat("yyyy-MM-dd'T'HH:mm:ss.sssZZ")
+        XCTAssertNotNil(date,"")
+    }
 }

--- a/Timepiece.playground/Contents.swift
+++ b/Timepiece.playground/Contents.swift
@@ -40,3 +40,9 @@ dateInCST.timeZone
 firstCommitDate < 1.year.ago
 (1.year.ago...now).contains(firstCommitDate)
 firstCommitDate > now
+
+//: #ISO8801
+let ISO8801Format = "yyyy-MM-dd'T'HH:mm:ss.sssZZ"
+let ISO8801FormattedString = now.stringFromFormat(ISO8801Format)
+let ISO8801DateString = "1987-06-02T20:25:43.422Z"
+let ISO8801Date = ISO8801DateString.dateFromFormat(ISO8801Format)


### PR DESCRIPTION
TODO: Fix this? 
the seconds format seems to cause the problem especially 'ss.sssZZ' instead of simply 'ssZZ' which does work