### PR TITLE
Made it possible to write 1.year.from(.tomorrow)

### DIFF
--- a/Sources/Date+Timepiece.swift
+++ b/Sources/Date+Timepiece.swift
@@ -112,27 +112,34 @@ extension Date {
     public init(year: Int, month: Int, day: Int) {
         self.init(year: year, month: month, day: day, hour: 0, minute: 0, second: 0)
     }
+    
+    /// Creates a new instance representing now.
+    ///
+    /// - returns: The created `Date` instance representing now.
+    public static var now: Date {
+        return Date()
+    }
 
     /// Creates a new instance representing today.
     ///
     /// - returns: The created `Date` instance representing today.
-    public static func today() -> Date {
-        let now = Date()
+    public static var today: Date {
+        let now = Date.now
         return Date(year: now.year, month: now.month, day: now.day)
     }
 
     /// Creates a new instance representing yesterday
     ///
     /// - returns: The created `Date` instance representing yesterday.
-    public static func yesterday() -> Date {
-        return (today() - 1.day)!
+    public static var yesterday: Date {
+        return (today - 1.day)!
     }
 
     /// Creates a new instance representing tomorrow
     ///
     /// - returns: The created `Date` instance representing tomorrow.
-    public static func tomorrow() -> Date {
-        return (today() + 1.day)!
+    public static var tomorrow: Date {
+        return (today + 1.day)!
     }
 
     /// Creates a new instance added a `DateComponents`

--- a/Sources/DateComponents+Timepiece.swift
+++ b/Sources/DateComponents+Timepiece.swift
@@ -10,11 +10,31 @@ import Foundation
 
 public extension DateComponents {
     var ago: Date? {
-        return Calendar.current.date(byAdding: -self, to: Date())
+        return before(.now)
     }
 
     var later: Date? {
-        return Calendar.current.date(byAdding: self, to: Date())
+        return after(.now)
+    }
+
+    func after(_ date: Date) -> Date? {
+        return date + self
+    }
+
+    func from(_ date: Date) -> Date? {
+        return after(date)
+    }
+
+    func since(_ date: Date) -> Date? {
+        return after(date)
+    }
+
+    func before(_ date: Date) -> Date? {
+        return date - self
+    }
+
+    func until(_ date: Date) -> Date? {
+        return before(date)
     }
 
     /// Creates inverse `DateComponents`

--- a/Tests/Date+TimepieceTests.swift
+++ b/Tests/Date+TimepieceTests.swift
@@ -90,7 +90,7 @@ class DateTests: XCTestCase {
     }
 
     func testToday() {
-        let today = Date.today()
+        let today = Date.today
         let now = Date()
 
         XCTAssertEqual(today.year, now.year)
@@ -102,7 +102,7 @@ class DateTests: XCTestCase {
     }
 
     func testYesterday() {
-        let yesterday = Date.yesterday()
+        let yesterday = Date.yesterday
         let date = Date() - 1.day
 
         XCTAssertEqual(yesterday.year, date?.year)
@@ -114,7 +114,7 @@ class DateTests: XCTestCase {
     }
 
     func testTomorrow() {
-        let tomorrow = Date.tomorrow()
+        let tomorrow = Date.tomorrow
         let date = Date() + 1.day
 
         XCTAssertEqual(tomorrow.year, date?.year)

--- a/Timepiece.playground/Contents.swift
+++ b/Timepiece.playground/Contents.swift
@@ -9,9 +9,9 @@ Date(year: 2014, month: 8, day: 14, hour: 20, minute: 25, second: 43, nanosecond
 Date(year: 2014, month: 8, day: 14, hour: 20, minute: 25, second: 43)
 Date(year: 2014, month: 8, day: 14)
 
-Date.today()
-Date.yesterday()
-Date.tomorrow()
+Date.today
+Date.yesterday
+Date.tomorrow
 
 // The properties of Date
 now.year
@@ -30,6 +30,8 @@ now + (3.weeks - 4.days + 5.hours)
 
 1.year.later
 1.year.ago
+
+1.year.from(.tomorrow)
 
 // Format
 now.string(inDateStyle: .long, andTimeStyle: .medium)


### PR DESCRIPTION
I added a few methods to the `DateComponents` extension which give a few more possibilities of creating dates in beautiful ways. For example, you can now write this:

```swift
let endOfTrial = 1.month.from(startOfTrial)
```

I also turned the static `yesterday()`, `today()` and `tomorrow()` methods into static computed properties, and I added a static computed `now` property to the `Date` extension. Now you can write things like:

```swift
let endOfTrial = 1.month.from(.now)
```

I find this easier to read than `1.month.later`, because when I read that I think: **`1 month later? later than what? oooh right, it means "1 month from now", I forgot.`**