### PR TITLE
Fixes App Store submission issue

### DIFF
--- a/Timepiece.xcodeproj/project.pbxproj
+++ b/Timepiece.xcodeproj/project.pbxproj
@@ -598,7 +598,6 @@
 		3DC61820199E1F8400FB7AAC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -649,7 +648,6 @@
 		3DC61821199E1F8400FB7AAC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";


### PR DESCRIPTION
ERROR ITMS-90171: "Invalid Bundle Structure - The binary file 'MyApp.app/Frameworks/Timepiece.framework/libswiftRemoteMirror.dylib' is not permitted. Your app can’t contain standalone executables or libraries, other than the CFBundleExecutable of supported bundles. Refer to the Bundle Programming Guide at https://developer.apple.com/go/?id=bundle-structure for information on the iOS app bundle structure."

Confirmed issue and cannot submit apps using Timepiece. Please see discussion #63.