### PR TITLE
Fix testDateInISO8601Format() availability

### DIFF
--- a/Tests/String+TimepieceTests.swift
+++ b/Tests/String+TimepieceTests.swift
@@ -17,7 +17,7 @@ class StringTests: XCTestCase {
         XCTAssertEqual(date?.day, 15)
     }
 
-    @available(iOS 10.0, *)
+    @available(iOS 10.0, OSX 10.12, *)
     func testDateInISO8601Format() {
         let date = "2014-08-15T20:25:43+0900".dateInISO8601Format()
         XCTAssertEqual(date?.year, 2014)


### PR DESCRIPTION
Hi, I was having problems building the macOS target using Carthage. This PR should fix it.

Thanks for the framework, it's awesome.