### PR TITLE
Create dates by changing the date components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 All notable changes to this project will be documented in this file.
 
 ## 1.0.2
-Unreleased yet.
+
+#### Added
+* `changed(year:month:day:hour:minute:second:nanosecond:)`, which creates a `Date` instance by changing receiver's date components.
+  * Added by [naoty](https://github.com/naoty) in [#77](https://github.com/naoty/Timepiece/pull/77)
+* `changed(weekday:)`, which creates a `Date` instance by changing receiver's weekday.
+  * Added by [naoty](https://github.com/naoty) in [#77](https://github.com/naoty/Timepiece/pull/77)
 
 #### Fixed
 * Fix testDateInISO8601Format() availability.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Intuitive date handling in Swift
 ## Features
 * :bulb: **Intuitive**: Timepiece provides a set of helpers to make date handling easier.
 * :clock9: **Correct**: Using Foundation API correctly, Timepiece helps to calculate dates correctly without deep understanding.
-* :package: **Small**: Timepiece has only 4 file and < 400 sloc. You can read the inside of this easily.
+* :package: **Small**: Timepiece has only 4 file. You can read the inside of this easily.
 
 ## Requirements
 
@@ -38,6 +38,12 @@ now + (3.weeks - 4.days + 5.hours)
 
 1.year.later
 1.year.ago
+```
+
+### Change
+
+```swift
+now.changed(year: 2014)
 ```
 
 ### Formating

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ now + (3.weeks - 4.days + 5.hours)
 
 ```swift
 now.changed(year: 2014)
+now.changed(weekday: 1)
 ```
 
 ### Formating

--- a/Sources/Date+Timepiece.swift
+++ b/Sources/Date+Timepiece.swift
@@ -155,6 +155,86 @@ extension Date {
         return Calendar.current.date(byAdding: -right, to: left)
     }
 
+    /// Creates a new instance by changing the date components
+    ///
+    /// - Parameters:
+    ///   - year: The year.
+    ///   - month: The month.
+    ///   - day: The day.
+    ///   - hour: The hour.
+    ///   - minute: The minute.
+    ///   - second: The second.
+    ///   - nanosecond: The nanosecond.
+    /// - Returns: The created `Date` instnace.
+    public func changed(year: Int? = nil, month: Int? = nil, day: Int? = nil, hour: Int? = nil, minute: Int? = nil, second: Int? = nil, nanosecond: Int? = nil) -> Date? {
+        var dateComponents = self.dateComponents
+        dateComponents.year = year ?? self.year
+        dateComponents.month = month ?? self.month
+        dateComponents.day = day ?? self.day
+        dateComponents.hour = hour ?? self.hour
+        dateComponents.minute = minute ?? self.minute
+        dateComponents.second = second ?? self.second
+        dateComponents.nanosecond = nanosecond ?? self.nanosecond
+
+        return calendar.date(from: dateComponents)
+    }
+
+    /// Creates a new instance by changing the year.
+    ///
+    /// - Parameter year: The year.
+    /// - Returns: The created `Date` instance.
+    public func changed(year: Int) -> Date? {
+        return changed(year: year, month: nil, day: nil, hour: nil, minute: nil, second: nil, nanosecond: nil)
+    }
+
+    /// Creates a new instance by changing the month.
+    ///
+    /// - Parameter month: The month.
+    /// - Returns: The created `Date` instance.
+    public func changed(month: Int) -> Date? {
+        return changed(year: nil, month: month, day: nil, hour: nil, minute: nil, second: nil, nanosecond: nil)
+    }
+
+    /// Creates a new instance by changing the day.
+    ///
+    /// - Parameter day: The day.
+    /// - Returns: The created `Date` instance.
+    public func changed(day: Int) -> Date? {
+        return changed(year: nil, month: nil, day: day, hour: nil, minute: nil, second: nil, nanosecond: nil)
+    }
+
+    /// Creates a new instance by changing the hour.
+    ///
+    /// - Parameter hour: The hour.
+    /// - Returns: The created `Date` instance.
+    public func changed(hour: Int) -> Date? {
+        return changed(year: nil, month: nil, day: nil, hour: hour, minute: nil, second: nil, nanosecond: nil)
+    }
+
+    /// Creates a new instance by changing the minute.
+    ///
+    /// - Parameter minute: The minute.
+    /// - Returns: The created `Date` instance.
+    public func changed(minute: Int) -> Date? {
+        return changed(year: nil, month: nil, day: nil, hour: nil, minute: minute, second: nil, nanosecond: nil)
+    }
+
+    /// Creates a new instance by changing the second.
+    ///
+    /// - Parameter second: The second.
+    /// - Returns: The created `Date` instance.
+    public func changed(second: Int) -> Date? {
+        return changed(year: nil, month: nil, day: nil, hour: nil, minute: nil, second: second, nanosecond: nil)
+    }
+
+    /// Creates a new instance by changing the nanosecond.
+    ///
+    /// - Parameter nanosecond: The nanosecond.
+    /// - Returns: The created `Date` instance.
+    public func changed(nanosecond: Int) -> Date? {
+        return changed(year: nil, month: nil, day: nil, hour: nil, minute: nil, second: nil, nanosecond: nanosecond)
+    }
+
     /// Creates a new `String` instance representing the receiver formatted in given date style and time style.
     ///
     /// - parameter dateStyle: The date style.

--- a/Sources/Date+Timepiece.swift
+++ b/Sources/Date+Timepiece.swift
@@ -235,6 +235,14 @@ extension Date {
         return changed(year: nil, month: nil, day: nil, hour: nil, minute: nil, second: nil, nanosecond: nanosecond)
     }
 
+    /// Creates a new instance by changing the weekday.
+    ///
+    /// - Parameter weekday: The weekday.
+    /// - Returns: The created `Date` instance.
+    public func changed(weekday: Int) -> Date? {
+        return self - (self.weekday - weekday).days
+    }
+
     /// Creates a new `String` instance representing the receiver formatted in given date style and time style.
     ///
     /// - parameter dateStyle: The date style.

--- a/Tests/Date+TimepieceTests.swift
+++ b/Tests/Date+TimepieceTests.swift
@@ -158,6 +158,19 @@ class DateTests: XCTestCase {
         XCTAssertEqual(newDate?.nanosecond, 0)
     }
 
+    func testChangedByWeekday() {
+        let date = Date(year: 2014, month: 8, day: 14, hour: 20, minute: 25, second: 43, nanosecond: 0)
+        let newDate = date.changed(weekday: 7)
+
+        XCTAssertEqual(newDate?.year, 2014)
+        XCTAssertEqual(newDate?.month, 8)
+        XCTAssertEqual(newDate?.day, 16)
+        XCTAssertEqual(newDate?.hour, 20)
+        XCTAssertEqual(newDate?.minute, 25)
+        XCTAssertEqual(newDate?.second, 43)
+        XCTAssertEqual(newDate?.nanosecond, 0)
+    }
+
     func testStringInStyles() {
         let sampleString = sample.string(inDateStyle: .short, andTimeStyle: .short)
         XCTAssertEqual(sampleString, "8/15/14, 8:25 PM")

--- a/Tests/Date+TimepieceTests.swift
+++ b/Tests/Date+TimepieceTests.swift
@@ -145,6 +145,19 @@ class DateTests: XCTestCase {
         XCTAssertEqual(added?.month, 12)
     }
 
+    func testChanged() {
+        let date = Date(year: 2014, month: 8, day: 14, hour: 20, minute: 25, second: 43, nanosecond: 0)
+        let newDate = date.changed(year: 2017)
+
+        XCTAssertEqual(newDate?.year, 2017)
+        XCTAssertEqual(newDate?.month, 8)
+        XCTAssertEqual(newDate?.day, 14)
+        XCTAssertEqual(newDate?.hour, 20)
+        XCTAssertEqual(newDate?.minute, 25)
+        XCTAssertEqual(newDate?.second, 43)
+        XCTAssertEqual(newDate?.nanosecond, 0)
+    }
+
     func testStringInStyles() {
         let sampleString = sample.string(inDateStyle: .short, andTimeStyle: .short)
         XCTAssertEqual(sampleString, "8/15/14, 8:25 PM")

--- a/Timepiece.playground/Contents.swift
+++ b/Timepiece.playground/Contents.swift
@@ -33,6 +33,7 @@ now + (3.weeks - 4.days + 5.hours)
 
 // Change
 now.changed(year: 2014)
+now.changed(weekday: 1)
 
 // Format
 now.string(inDateStyle: .long, andTimeStyle: .medium)

--- a/Timepiece.playground/Contents.swift
+++ b/Timepiece.playground/Contents.swift
@@ -31,6 +31,9 @@ now + (3.weeks - 4.days + 5.hours)
 1.year.later
 1.year.ago
 
+// Change
+now.changed(year: 2014)
+
 // Format
 now.string(inDateStyle: .long, andTimeStyle: .medium)
 now.dateString(in: .medium)


### PR DESCRIPTION
Following methods will be added.

```swift
now.changed(year: 2017)
now.changed(weekday: 1)
```

These methods were in `0.4.x`. This PR will take back them.