### PR TITLE
Specify Swift version

### DIFF
--- a/Timepiece.xcodeproj/project.pbxproj
+++ b/Timepiece.xcodeproj/project.pbxproj
@@ -877,6 +877,7 @@
 				PRODUCT_NAME = Timepiece;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -900,6 +901,7 @@
 				PRODUCT_NAME = Timepiece;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};


### PR DESCRIPTION
This is needed to compile the watchOS target on Xcode 8.2