### PR TITLE
Add methods to create a Date by truncating the components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+* `truncated(_:)`, which creates a `Date` instance by truncating the components.
+* `truncated(from:)`, which creates a `Date` instance by truncating the components from a given component.
+
 ## 1.1.0
 Released on 2017-01-06.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ now + (3.weeks - 4.days + 5.hours)
 ```swift
 now.changed(year: 2014)
 now.changed(weekday: 1)
+now.truncated([.minute, .second, .nanosecond])
+now.truncated(from: .day)
 ```
 
 ### Formating

--- a/Sources/Date+Timepiece.swift
+++ b/Sources/Date+Timepiece.swift
@@ -243,6 +243,58 @@ extension Date {
         return self - (self.weekday - weekday).days
     }
 
+    /// Creates a new instance by truncating the components
+    ///
+    /// - Parameter components: The components to be truncated.
+    /// - Returns: The created `Date` instance.
+    public func truncated(_ components: [Calendar.Component]) -> Date? {
+        var dateComponents = self.dateComponents
+
+        for component in components {
+            switch component {
+            case .month:
+                dateComponents.month = 1
+            case .day:
+                dateComponents.day = 1
+            case .hour:
+                dateComponents.hour = 0
+            case .minute:
+                dateComponents.minute = 0
+            case .second:
+                dateComponents.second = 0
+            case .nanosecond:
+                dateComponents.nanosecond = 0
+            default:
+                continue
+            }
+        }
+        
+        return calendar.date(from: dateComponents)
+    }
+
+    /// Creates a new instance by truncating the components
+    ///
+    /// - Parameter component: The component to be truncated from.
+    /// - Returns: The created `Date` instance.
+    public func truncated(from component: Calendar.Component) -> Date? {
+        switch component {
+        case .month:
+            return truncated([.month, .day, .hour, .minute, .second, .nanosecond])
+        case .day:
+            return truncated([.day, .hour, .minute, .second, .nanosecond])
+        case .hour:
+            return truncated([.hour, .minute, .second, .nanosecond])
+        case .minute:
+            return truncated([.minute, .second, .nanosecond])
+        case .second:
+            return truncated([.second, .nanosecond])
+        case .nanosecond:
+            return truncated([.nanosecond])
+        default:
+            return self
+        }
+    }
+
     /// Creates a new `String` instance representing the receiver formatted in given date style and time style.
     ///
     /// - parameter dateStyle: The date style.

--- a/Tests/Date+TimepieceTests.swift
+++ b/Tests/Date+TimepieceTests.swift
@@ -171,6 +171,32 @@ class DateTests: XCTestCase {
         XCTAssertEqual(newDate?.nanosecond, 0)
     }
 
+    func testTruncated() {
+        let date = Date(year: 2014, month: 8, day: 14, hour: 20, minute: 25, second: 43, nanosecond: 0)
+        let newDate = date.truncated([.hour, .minute, .second, .nanosecond])
+
+        XCTAssertEqual(newDate?.year, 2014)
+        XCTAssertEqual(newDate?.month, 8)
+        XCTAssertEqual(newDate?.day, 14)
+        XCTAssertEqual(newDate?.hour, 0)
+        XCTAssertEqual(newDate?.minute, 0)
+        XCTAssertEqual(newDate?.second, 0)
+        XCTAssertEqual(newDate?.nanosecond, 0)
+    }
+
+    func testTruncatedFrom() {
+        let date = Date(year: 2014, month: 8, day: 14, hour: 20, minute: 25, second: 43, nanosecond: 0)
+        let newDate = date.truncated(from: .month)
+
+        XCTAssertEqual(newDate?.year, 2014)
+        XCTAssertEqual(newDate?.month, 1)
+        XCTAssertEqual(newDate?.day, 1)
+        XCTAssertEqual(newDate?.hour, 0)
+        XCTAssertEqual(newDate?.minute, 0)
+        XCTAssertEqual(newDate?.second, 0)
+        XCTAssertEqual(newDate?.nanosecond, 0)
+    }
+
     func testStringInStyles() {
         let sampleString = sample.string(inDateStyle: .short, andTimeStyle: .short)
         XCTAssertEqual(sampleString, "8/15/14, 8:25 PM")

--- a/Timepiece.playground/Contents.swift
+++ b/Timepiece.playground/Contents.swift
@@ -34,6 +34,8 @@ now + (3.weeks - 4.days + 5.hours)
 // Change
 now.changed(year: 2014)
 now.changed(weekday: 1)
+now.truncated([.minute, .second, .nanosecond])
+now.truncated(from: .day)
 
 // Format
 now.string(inDateStyle: .long, andTimeStyle: .medium)


### PR DESCRIPTION
This PR adds below methods.

```swift
let date = Date(year: 2014, month: 8, day: 14, hour: 20, minute: 25, second: 43)
date.truncated([.month, .day]) //=> Date(year: 2014, month: 1, day: 1, hour: 20, minute: 25, second: 43)
date.truncated(from: .hour) //=> Date(year: 2014, month: 8, day: 14, hour: 0, minute: 0, second: 0)
```

These are useful when you want the beginning of a period. For example, if you want to filter commits in this month, you will be able to write below.

```swift
let firstDay = Date().truncated(from: .day)!
let nextFirstDay = (firstDay + 1.month)!
commits.filter { (firstDay ..< nextFirstDay).contains($0.commitDate) }
```

Feel free to post a reaction or comment.