### PR TITLE
`stringIn(dateFormat:)` method for LDML Date representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## 1.2.1
+Released on 2017-08-21.
+
+### Added
+* `stringIn(dateFormat:)`, which creates a `String` representation of `Date` instance based on LDML format string.
+
 ## 1.2.0
 Released on 2017-04-30.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ now.truncated(from: .day)
 now.stringIn(dateStyle: .long, timeStyle: .medium)
 now.dateString(in: .medium)
 now.timeString(in: .short)
+now.stringIn(dateFormat: "'LDML representation:' yyyy/MM/dd"))
 
 3.days.string(in: .full)
 ```

--- a/Sources/Date+Timepiece.swift
+++ b/Sources/Date+Timepiece.swift
@@ -331,4 +331,16 @@ extension Date {
     public func timeString(in timeStyle: DateFormatter.Style) -> String {
         return stringIn(dateStyle: .none, timeStyle: timeStyle)
     }
+    
+    /// Creates a new `String` instance representing the receiver formatted in given custom LDML format string.
+    ///
+    /// - parameter dateFormat: The LDML format string (see http://www.unicode.org/reports/tr35/tr35-45/tr35-dates.html#Date_Field_Symbol_Table for reference)
+    ///
+    /// - returns: The created `String` instance.
+    public func stringIn(dateFormat: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = dateFormat
+        
+        return dateFormatter.string(from: self)
+    }
 }

--- a/Tests/TimepieceTests/Date+TimepieceTests.swift
+++ b/Tests/TimepieceTests/Date+TimepieceTests.swift
@@ -211,4 +211,9 @@ class DateTests: XCTestCase {
         let sampleString = sample.timeString(in: .short)
         XCTAssertEqual(sampleString, "8:25 PM")
     }
+    
+    func testStringInFormat() {
+        let sampleString = sample.stringIn(dateFormat: "yyyy-MM-dd")
+        XCTAssertEqual(sampleString, "2014-08-15")
+    }
 }

--- a/Timepiece.playground/Contents.swift
+++ b/Timepiece.playground/Contents.swift
@@ -41,6 +41,7 @@ now.truncated(from: .day)
 now.stringIn(dateStyle: .long, timeStyle: .medium)
 now.dateString(in: .medium)
 now.timeString(in: .short)
+now.stringIn(dateFormat: "yyyy-MM-dd")
 
 3.days.string(in: .full)
 

--- a/Timepiece.podspec
+++ b/Timepiece.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Timepiece"
-  s.version      = "1.2.0"
+  s.version      = "1.2.1"
   s.summary      = "Intuitive date handling in Swift"
   s.homepage     = "https://github.com/naoty/Timepiece"
   s.license      = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
Added `stringIn(dateFormat:)` method in `Date+Timepiece` extension to create String from Date based on LDML format string (http://www.unicode.org/reports/tr35/tr35-45/tr35-dates.html#Date_Field_Symbol_Table)