### PR TITLE
Remove unnecessary timeZone for ISO formatter

### DIFF
--- a/Sources/String+Timepiece.swift
+++ b/Sources/String+Timepiece.swift
@@ -32,7 +32,6 @@ extension String {
     public func dateInISO8601Format(with options: ISO8601DateFormatter.Options = [.withInternetDateTime]) -> Date? {
         let dateFormatter = ISO8601DateFormatter()
         dateFormatter.formatOptions = options
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
         return dateFormatter.date(from: self)
     }


### PR DESCRIPTION
The time zone is handled in the Swift source code already:
https://github.com/apple/swift-corelibs-foundation/blob/4f228b782ee2c596eccf14eea6dfd184c187a022/Foundation/ISO8601DateFormatter.swift#L77