### PR TITLE
fix typo that prevents cocoapods installation

### DIFF
--- a/Timepiece.podspec
+++ b/Timepiece.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
 
   s.source       = { :git => "https://github.com/naoty/Timepiece.git", :tag => s.version }
-  s.source_files  = "Sources/**/*.swift"
+  s.source_files  = "Sources/**/*.{swift}"
   s.requires_arc = true
   s.swift_version = '5.0'
 end


### PR DESCRIPTION
With Cocoapods version 1.8.3, try to update or install pod was sending this error messages: 

```
- `Timepiece-library` does not specify a Swift version and none of the targets (`Pods`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.
```

after some investigation, there was a small typo in the podspect. Fixed the typo there is no error anymore